### PR TITLE
Add complete 354 reply message

### DIFF
--- a/src/main/java/ch/astorm/smtp4j/protocol/SmtpTransactionHandler.java
+++ b/src/main/java/ch/astorm/smtp4j/protocol/SmtpTransactionHandler.java
@@ -122,7 +122,7 @@ public class SmtpTransactionHandler {
                 }
 
                 smtpMessageContent = new StringBuilder(256);
-                reply(SmtpProtocolConstants.CODE_INTERMEDIATE_REPLY, null);
+                reply(SmtpProtocolConstants.CODE_INTERMEDIATE_REPLY, "End data with <CR><LF>.<CR><LF>");
 
                 String currentLine = nextLine();
                 while(currentLine!=null) {

--- a/src/main/java/ch/astorm/smtp4j/protocol/SmtpTransactionHandler.java
+++ b/src/main/java/ch/astorm/smtp4j/protocol/SmtpTransactionHandler.java
@@ -122,7 +122,7 @@ public class SmtpTransactionHandler {
                 }
 
                 smtpMessageContent = new StringBuilder(256);
-                reply(SmtpProtocolConstants.CODE_INTERMEDIATE_REPLY, "End data with <CR><LF>.<CR><LF>");
+                reply(SmtpProtocolConstants.CODE_INTERMEDIATE_REPLY, "Start mail input; end with <CRLF>.<CRLF>");
 
                 String currentLine = nextLine();
                 while(currentLine!=null) {


### PR DESCRIPTION
Some clients seem to have problems when a 354 is replied without the message "End data with <CR><LF>.<CR><LF>". 
In this case it was powershells send-mailmessage. For details on the problem please see #60.